### PR TITLE
Fix data entry for Jihocesky kraj.

### DIFF
--- a/data_sources.py
+++ b/data_sources.py
@@ -5,8 +5,8 @@ source_files = {
                  "Jihocesky": [
                               "C2BYNO01_T_N.csv.zip",
                               "C2CBUD01_T_N.csv.zip",
-                              "C1PLAN01_T_N.csv",
-                              "C2HSTR01_T_N.csv",
+                              "C1PLAN01_T_N.csv.zip",
+                              "C2HSTR01_T_N.csv.zip",
                               ],
                  "Stredocesky": [
                               "P3HULI01_T_N.csv.zip",


### PR DESCRIPTION
Data files in Jihocesky kraj were missing `.zip` suffix.